### PR TITLE
Fix broken star history chart

### DIFF
--- a/.github/README.template.md
+++ b/.github/README.template.md
@@ -154,5 +154,5 @@ Donate (Bitcoin Address): `1MMDRZAcM6dzmdMUSV8pDdAPDFpwzve9Fc`
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Pymmdrza/rich-address-wallet&type=Date)](https://star-history.com/#Pymmdrza/rich-address-wallet&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Pymmdrza/rich-address-wallet&type=Date)](https://star-history.dera.page/#Pymmdrza/rich-address-wallet&Date)
   

--- a/README.md
+++ b/README.md
@@ -161,3 +161,7 @@ Donate (Bitcoin Address): `1MMDRZAcM6dzmdMUSV8pDdAPDFpwzve9Fc`
 - Email : [a.i@Programmer.net](mailto:a.i@programmer.net) | [first@Programmer.net](mailto:first@programmer.net)
 
 
+
+  ## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=Pymmdrza/rich-address-wallet&type=Date)](https://star-history.dera.page/#Pymmdrza/rich-address-wallet&Date)


### PR DESCRIPTION
The star history chart on this repository is currently broken due to recent GitHub API restrictions. This change makes the chart work again and restores the Star History section that was previously removed in commit 476e9a1.